### PR TITLE
電卓周りの調整

### DIFF
--- a/CustomKeyboard/Classes/CustomKeyboard.swift
+++ b/CustomKeyboard/Classes/CustomKeyboard.swift
@@ -625,6 +625,20 @@ open class CustomKeyboard: UIInputView, UITextFieldDelegate, UIGestureRecognizer
             calculate()
         }
         
+        guard let doubleZeroButton = findButton(by: 10) else {
+            fatalError("not found the button with the tag")
+        }
+        guard let zeroButton = findButton(by: 11) else {
+            fatalError("not found the button with the tag")
+        }
+        if currentOperator == "➗" {
+            doubleZeroButton.isEnabled = false
+            zeroButton.isEnabled = false
+        } else {
+            doubleZeroButton.isEnabled = true
+            zeroButton.isEnabled = true
+        }
+        
         switch button.tag {
         case 12 + 1:                  // 除
             currentOperator = "➗"
@@ -657,6 +671,15 @@ open class CustomKeyboard: UIInputView, UITextFieldDelegate, UIGestureRecognizer
             default:
                 finalNumber = 0
             }
+            
+            if finalNumber > 999999999 {
+                finalNumber = 999999999
+            }
+            
+            if finalNumber < -999999999 {
+                finalNumber = -999999999
+            }
+            
             firstResponder()?.text = ""
             firstResponder()?.insertText(String(finalNumber))
             currentOperator = ""


### PR DESCRIPTION
## 目的:
計算結果最大値、最小値の設定
0で割ろうとしたとき０、００ボタンのタップを禁止
## 変更点:
計算結果は出す前最大値、最小値の判定を入れる。
`/` を押す時０、００ボタンの `isEnabled`を切り替え。
## 結果:
- [x] 最大値、最小値の反映確認
- [x] ０、００ボタンのオンオフ確認