### PR TITLE
マイナスの値を入力可能

### DIFF
--- a/CustomKeyboard/Classes/CustomKeyboard.swift
+++ b/CustomKeyboard/Classes/CustomKeyboard.swift
@@ -521,7 +521,9 @@ open class CustomKeyboard: UIInputView, UITextFieldDelegate, UIGestureRecognizer
             switch sender.tag {
             case 12:                        // 删除
                 handleDelete(button: sender)
-            case 12 + 1, 13 + 1, 14 + 1, 15 + 1:            // 除乘减加
+            case 14 + 1:
+                negativeNumber(button: sender)
+            case 12 + 1, 13 + 1, 15 + 1:            // 除乘减加
                 calculateOperator(button: sender)
             case 16 + 1:            // 隐藏键盘\确定键,辞去第一响应者
                 if currentOperator == "" {
@@ -615,6 +617,15 @@ open class CustomKeyboard: UIInputView, UITextFieldDelegate, UIGestureRecognizer
                 firstResponder()?.text = "0"
             }
             formatTextField()
+        }
+    }
+    
+    private func negativeNumber(button: UIButton) {
+        if previousNumber == 0 {
+            firstResponder()?.text = ""
+            firstResponder()?.insertText("-")
+        } else {
+            calculateOperator(button: button)
         }
     }
     


### PR DESCRIPTION
## 目的:
マイナスの値を入力可能
## 変更点:
マイナスをタップする時、オペランドが0の場合 `-` を付ける
## 結果:
- [x] マイナスの値を入力可能
- [x] 値計算
- [x] deleteボタンの動作 

確認方法：
podfileを編集
`pod 'Customkeyboard', :git => 'git@github.com:r-n-i/CustomKeyboard.git', :branch => 'negative_number_input', :commit => '26fc3d2b31ce77f211176d5c7c55a52c9671b05f'`


https://user-images.githubusercontent.com/44150335/126921183-b67db9df-76df-41e8-ab10-92a8aeb3ed24.MP4

